### PR TITLE
Fix wrong license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/Sandermoen/instaclone/issues"
   },


### PR DESCRIPTION
`license` field in package.json is ISC, but in the LICENSE file, Apache License 2.0 seems applied to this repository.
I guess the ISC license is the wrong license for this repository.